### PR TITLE
Handle 0 properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function toPx (length) {
     if (!match || match.length < 3) break
     var val = Number(match[1])
     if (isNaN(val)) break
+    if(val === 0) break
     var unit = match[2]
     if (!unit) break
     var valid = true


### PR DESCRIPTION
Added check to handle 0, example "0rem" properly. Previously ` 1 ` was being returned instead of ` 0 `.